### PR TITLE
fix(macos): respect disabled state for menu items

### DIFF
--- a/src/platform/macos/menu_macos.mm
+++ b/src/platform/macos/menu_macos.mm
@@ -124,6 +124,10 @@ std::pair<NSString*, NSUInteger> ConvertAccelerator(const KeyboardAccelerator& a
     if (!menu_item)
       return;
 
+    // Ignore clicks on disabled items as an extra safety net.
+    if (![menu_item isEnabled])
+      return;
+
     // Call the block if it exists
     if (_clickedBlock) {
       // Get the MenuItemId from the menu item's associated object
@@ -160,6 +164,14 @@ std::pair<NSString*, NSUInteger> ConvertAccelerator(const KeyboardAccelerator& a
     // Log the exception but don't crash
     NSLog(@"Exception in menuWillOpen: %@", [exception reason]);
   }
+}
+
+- (BOOL)menu:(NSMenu*)menu validateMenuItem:(NSMenuItem*)item {
+  // Respect the programmatically set enabled state on NSMenuItem.
+  // Without this override, NSMenu's default autoenablesItems (YES)
+  // would re-enable all items whose target responds to the action,
+  // overriding explicit setEnabled:NO calls.
+  return [item isEnabled];
 }
 
 - (void)menuDidClose:(NSMenu*)menu {
@@ -509,6 +521,8 @@ class Menu::Impl {
   Impl(MenuId id, NSMenu* menu)
       : id_(id), ns_menu_(menu), delegate_([[NSMenuDelegateImpl alloc] init]) {
     [ns_menu_ setDelegate:delegate_];
+    // Disable auto-enabling so explicit setEnabled: calls are respected.
+    [ns_menu_ setAutoenablesItems:NO];
   }
 
   ~Impl() {


### PR DESCRIPTION
### Problem

When calling `MenuItem::SetEnabled(false)` on macOS, the disabled menu item remains clickable. This happens because:

1. `NSMenu` has `autoenablesItems` enabled by default, which overrides explicit `setEnabled:` calls during menu validation.
2. The `menuItemClicked:` handler did not check the item's enabled state.

### Changes

- **Set `autoenablesItems = NO`** on `NSMenu` so that explicitly set enabled states are always respected.
- **Add `isEnabled` check** in `menuItemClicked:` callback as an extra safety net — if AppKit still sends the action for a disabled item, the handler ignores it.
- **Implement `menu:validateMenuItem:`** in `NSMenuDelegateImpl` to return the item's actual `isEnabled` state.

### Testing

Verified that a disabled menu item now appears grayed out and does not fire `MenuItemClickedEvent` when clicked.