### PR TITLE
fix(macos): handle double-click on hidden title bar

### DIFF
--- a/examples/window_example/main.cpp
+++ b/examples/window_example/main.cpp
@@ -35,6 +35,7 @@ int main() {
   // Create a new window (automatically registered)
   std::shared_ptr<Window> window_ptr = std::make_shared<Window>();
   window_ptr->SetTitle("Window Example");
+  window_ptr->SetTitleBarStyle(nativeapi::TitleBarStyle::Hidden);
   window_ptr->SetSize({800, 600}, false);
   window_ptr->SetMinimumSize({400, 300});
   window_ptr->SetMaximumSize({1920, 1080});

--- a/src/platform/macos/window_macos.mm
+++ b/src/platform/macos/window_macos.mm
@@ -12,6 +12,40 @@
 // Key for associated objects (used by both window_macos.mm and window_manager_macos.mm)
 const void* kWindowIdKey = &kWindowIdKey;
 
+@interface NativeAPIWindow : NSWindow
+@end
+
+@implementation NativeAPIWindow
+
+- (void)mouseUp:(NSEvent*)event {
+  if (event.clickCount == 2) {
+    if ((self.styleMask & NSWindowStyleMaskFullSizeContentView) &&
+        self.titlebarAppearsTransparent) {
+      NSPoint locationInWindow = [event locationInWindow];
+      NSRect contentLayoutRect = [self contentLayoutRect];
+      NSRect windowFrame = [[self contentView] frame];
+
+      NSRect titleBarRect = NSMakeRect(
+          contentLayoutRect.origin.x, contentLayoutRect.origin.y + contentLayoutRect.size.height,
+          contentLayoutRect.size.width, windowFrame.size.height - contentLayoutRect.size.height);
+
+      if (NSPointInRect(locationInWindow, titleBarRect)) {
+        NSString* action =
+            [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleActionOnDoubleClick"];
+        if ([action isEqualToString:@"Minimize"]) {
+          [self miniaturize:nil];
+        } else {
+          [self performZoom:nil];
+        }
+        return;
+      }
+    }
+  }
+  [super mouseUp:event];
+}
+
+@end
+
 namespace nativeapi {
 
 // Private implementation class
@@ -39,7 +73,7 @@ Window::Window(void* native_window) {
   if (native_window == nullptr) {
     // Create new platform object
     id = IdAllocator::Allocate<Window>();
-    ns_window = [[NSWindow alloc] init];
+    ns_window = [[NativeAPIWindow alloc] init];
     ns_window.styleMask = NSWindowStyleMaskResizable | NSWindowStyleMaskTitled |
                           NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
     // Store the ID as associated object


### PR DESCRIPTION
### Problem

When `TitleBarStyle::Hidden` is set on macOS, double-clicking the title bar area does nothing. The default `NSWindow` behavior for handling double-click events is lost when the title bar is hidden using `NSWindowStyleMaskFullSizeContentView` and `titlebarAppearsTransparent`. #48 

### Changes

- **Create `NativeAPIWindow`** : Subclass of `NSWindow` that overrides `mouseUp:` to detect double-clicks in the title bar region
- **Implement hit testing**: Calculate title bar rect using `contentLayoutRect` and `contentView` frame
- **Respect system preferences**: Read `AppleActionOnDoubleClick` from `NSUserDefaults` to determine whether to call `miniaturize:` or `performZoom:`
- **Update window creation**: Replace `NSWindow` with `NativeAPIWindow` in `window_macos.mm`
- **Update example**: Add `SetTitleBarStyle(nativeapi::TitleBarStyle::Hidden)` to `window_example/main.cpp`

### Testing

Verified that double-clicking the title bar area now triggers zoom (default) or minimize based on the user's system preference setting. Single-click and clicks outside the title bar area are unaffected.